### PR TITLE
Add TensorRT model conversion and evaluation pipeline

### DIFF
--- a/trt_pipeline/model_convert.py
+++ b/trt_pipeline/model_convert.py
@@ -1,5 +1,4 @@
 import argparse
-#import onnxsim
 import onnx
 import torch
 import os
@@ -8,15 +7,22 @@ from model.torch_tracker_wrapper import TorchTrackerWrapper
 
 
 def convert_to_jit(cfg_path, ckpt_path):
+    """Convert a PyTorch checkpoint to TorchScript.
+
+    Returns the path to the saved TorchScript model (.pt).
+    """
     wrapper = TorchTrackerWrapper(cfg_path, ckpt_path)
-
     model_jit = torch.jit.script(wrapper.network)
-    model_jit.save(ckpt_path[:-1])
 
-    print('[INFO] Model successfully converted to jit-script:', ckpt_path[:-1])
+    model_path, _ = os.path.splitext(ckpt_path)
+    jit_path = model_path + '.pt'
+    model_jit.save(jit_path)
+    print('[INFO] Model successfully converted to jit-script:', jit_path)
+    return jit_path
 
 
 def convert_to_onnx(cfg_path, ckpt_path):
+    """Export the tracker network to ONNX and return the simplified model path."""
     wrapper = TorchTrackerWrapper(cfg_path, ckpt_path)
 
     dummy_template = torch.randn((1, 3, wrapper.template_size, wrapper.template_size), dtype=torch.float32).cuda()
@@ -36,28 +42,24 @@ def convert_to_onnx(cfg_path, ckpt_path):
                       output_names=['bbox', 'confidence'],
                       dynamic_axes=None)
 
-    model_onnx = onnx.load(model_path_onnx)     # load onnx model
-    onnx.checker.check_model(model_onnx)        # check onnx model
-
+    model_onnx = onnx.load(model_path_onnx)
+    onnx.checker.check_model(model_onnx)
     print('[INFO] Model successfully converted to onnx:', model_path_onnx)
 
-    cuda = torch.cuda.is_available()
-    if not cuda:
+    if not torch.cuda.is_available():
         print('[WARNING] Cuda is not avalible :(')
 
-    #model_onnx, check = onnxsim.simplify(model_onnx)
-    #assert check, '[ERROR] Assert onnx-simplified check failed'
-    onnx.save(model_onnx, model_path + '_simple.onnx')
-
-    print('[INFO] Onnx model successfully simplified:', 
-          model_path + '_simple.onnx')
+    simple_path = model_path + '_simple.onnx'
+    onnx.save(model_onnx, simple_path)
+    print('[INFO] Onnx model successfully simplified:', simple_path)
+    return simple_path
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', type=str)
     parser.add_argument('--ckpt', type=str)
-    parser.add_argument('--mod', type=str, help='jit / onnx / engine')
+    parser.add_argument('--mod', type=str, help='jit / onnx')
 
     args = parser.parse_args()
 

--- a/trt_pipeline/trt_convert.py
+++ b/trt_pipeline/trt_convert.py
@@ -1,19 +1,50 @@
+import argparse
 import tensorrt as trt
 
-TRT_LOGGER = trt.Logger(trt.Logger.WARNING)
 
-# Инициализация TensorRT билдера и парсера ONNX
-with trt.Builder(TRT_LOGGER) as builder, builder.create_network(1) as network, trt.OnnxParser(network,
-                                                                                              TRT_LOGGER) as parser:
-    # Загрузка ONNX-модели и парсинг в TensorRT
-    with open("/home/ilya/PycharmProjects/Trackers/MixformerBench/weight-cfg/mixformer2_base.onnx", "rb") as model_file:
-        parser.parse(model_file.read())
+def build_engine(onnx_path: str, engine_path: str, fp16: bool = False, workspace: int = 1 << 30):
+    """Build a TensorRT engine from ONNX model.
 
-    builder_config = builder.create_builder_config()
-    builder_config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 32)
-    builder_config.set_tactic_sources(1 << int(trt.TacticSource.CUBLAS))
-    builder_config.set_flag(trt.BuilderFlag.FP16)
+    Args:
+        onnx_path: Path to ONNX model.
+        engine_path: Where to write serialized engine.
+        fp16: Enable FP16 precision.
+        workspace: Workspace size in bytes.
+    Returns:
+        Path to the serialized engine.
+    """
+    logger = trt.Logger(trt.Logger.WARNING)
+    flag = 1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+    with trt.Builder(logger) as builder, builder.create_network(flag) as network, \
+            trt.OnnxParser(network, logger) as parser:
+        with open(onnx_path, 'rb') as model:
+            if not parser.parse(model.read()):
+                for i in range(parser.num_errors):
+                    print(parser.get_error(i))
+                raise RuntimeError("Failed to parse ONNX model")
 
-    serialized_network = builder.build_serialized_network(network, builder_config)
-    with open("mixformer2_base.engine", "wb") as f:
-        f.write(serialized_network)
+        config = builder.create_builder_config()
+        config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, workspace)
+        if fp16:
+            config.set_flag(trt.BuilderFlag.FP16)
+
+        serialized_engine = builder.build_serialized_network(network, config)
+        with open(engine_path, 'wb') as f:
+            f.write(serialized_engine)
+    print(f"[INFO] TensorRT engine saved to {engine_path}")
+    return engine_path
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Convert ONNX model to TensorRT engine")
+    ap.add_argument('--onnx', required=True, help='Path to ONNX model')
+    ap.add_argument('--engine', required=True, help='Output path for TensorRT engine')
+    ap.add_argument('--fp16', action='store_true', help='Enable FP16 precision')
+    ap.add_argument('--workspace', type=int, default=1 << 30, help='Workspace size in bytes')
+    args = ap.parse_args()
+
+    build_engine(args.onnx, args.engine, fp16=args.fp16, workspace=args.workspace)
+
+
+if __name__ == '__main__':
+    main()

--- a/trt_pipeline/trt_pipeline.py
+++ b/trt_pipeline/trt_pipeline.py
@@ -1,0 +1,60 @@
+import argparse
+import os
+from model_convert import convert_to_onnx
+from trt_convert import build_engine
+from tracking_test_uav123V3 import run_tracking_evaluation
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Full conversion and evaluation pipeline')
+    parser.add_argument('--config', required=True, help='Path to tracker config file')
+    parser.add_argument('--ckpt', required=True, help='Path to PyTorch checkpoint (.pth)')
+    parser.add_argument('--data_root', required=True, help='Root directory of UAV123 dataset images')
+    parser.add_argument('--anno_root', required=True, help='Root directory of UAV123 annotations')
+    parser.add_argument('--output_dir', required=True, help='Directory to store evaluation results')
+    parser.add_argument('--matlab_config', required=True, help='Path to UAV123 MATLAB config file')
+    parser.add_argument('--workspace', type=int, default=1 << 30, help='TensorRT workspace size in bytes')
+    args = parser.parse_args()
+
+    onnx_path = convert_to_onnx(args.config, args.ckpt)
+
+    builder_variants = [
+        {'name': 'fp32', 'fp16': False},
+        {'name': 'fp16', 'fp16': True},
+    ]
+
+    results = []
+    for variant in builder_variants:
+        engine_path = os.path.splitext(args.ckpt)[0] + f"_{variant['name']}.engine"
+        try:
+            build_engine(onnx_path, engine_path, fp16=variant['fp16'], workspace=args.workspace)
+        except Exception as e:
+            print(f"[ERROR] Failed to build engine for {variant['name']}: {e}")
+            continue
+
+        metrics, _, _ = run_tracking_evaluation(
+            args.config,
+            engine_path,
+            args.data_root,
+            args.anno_root,
+            args.output_dir,
+            args.matlab_config,
+            "",
+            False,
+            False,
+        )
+        score = metrics.get('Avg_IoU', 0) * metrics.get('Avg_FPS', 0)
+        results.append({'name': variant['name'], 'engine': engine_path, 'metrics': metrics, 'score': score})
+        print(f"[RESULT] {variant['name']}: IoU={metrics.get('Avg_IoU', 0):.3f} FPS={metrics.get('Avg_FPS', 0):.2f}")
+
+    if results:
+        best = max(results, key=lambda x: x['score'])
+        print('[BEST] configuration:', best['name'])
+        print('[BEST] engine:', best['engine'])
+        print('[BEST] metrics:', best['metrics'])
+    else:
+        print('No successful evaluations')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `trt_pipeline.py` to convert MixFormer checkpoints to ONNX/TensorRT, evaluate on UAV123, and search FP32/FP16 engines
- add reusable `trt_convert.py` helper for TensorRT engine building
- update `model_convert.py` to return file paths for further processing

## Testing
- `python -m py_compile model_convert.py trt_convert.py trt_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2d8e20f088326b0266c12f450a0de