### PR TITLE
Fix INT8 builder configuration

### DIFF
--- a/trt_pipeline/trt_convert.py
+++ b/trt_pipeline/trt_convert.py
@@ -130,12 +130,10 @@ def build_engine(
         if int8:
             if calib_dir is None:
                 raise ValueError("calib_dir must be provided when int8=True")
-            builder.int8_mode = True
             config.set_flag(trt.BuilderFlag.INT8)
             input_shape = tuple(network.get_input(0).shape)[1:]
             cache = calib_cache or engine_path + ".calib"
             calibrator = UAV123Calibrator(calib_dir, input_shape, cache)
-            builder.int8_calibrator = calibrator
             config.int8_calibrator = calibrator
 
         serialized_engine = builder.build_serialized_network(network, config)


### PR DESCRIPTION
## Summary
- remove deprecated builder.int8_mode and builder.int8_calibrator
- rely on builder config flags for INT8 calibration

## Testing
- `python -m py_compile trt_pipeline/trt_convert.py`
- `python trt_pipeline/trt_convert.py --help` *(fails: ModuleNotFoundError: No module named 'tensorrt')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2dfcc7e608326aa24255254934384